### PR TITLE
automate shows sorting, adding shows.js and shows.json

### DIFF
--- a/assets/js/shows.js
+++ b/assets/js/shows.js
@@ -1,0 +1,51 @@
+// Helper to parse YYYY-MM-DD as a local date
+function parseLocalDate(dateStr) {
+    const [year, month, day] = dateStr.split('-').map(Number);
+    return new Date(year, month - 1, day); // JS months are 0-indexed
+  }
+  
+  async function loadShows() {
+    try {
+      const response = await fetch('assets/js/shows.json');
+      const shows = await response.json();
+  
+      const today = new Date();
+      today.setHours(0, 0, 0, 0); // strip time
+  
+      // Parse dates as local
+      const upcoming = shows.filter(s => parseLocalDate(s.date) >= today);
+      const past = shows.filter(s => parseLocalDate(s.date) < today);
+  
+      // Sort
+      upcoming.sort((a, b) => parseLocalDate(a.date) - parseLocalDate(b.date));
+      past.sort((a, b) => parseLocalDate(b.date) - parseLocalDate(a.date));
+  
+      renderShows(upcoming, document.getElementById('upcoming-shows'));
+      renderShows(past, document.getElementById('past-shows'));
+    } catch (err) {
+      console.error('Error loading shows:', err);
+    }
+  }
+  
+  function renderShows(list, container) {
+    container.innerHTML = list.map(show => {
+      const showDate = parseLocalDate(show.date);
+      return `
+        <li>
+          <div class="show-datetime">
+            <span class="show-date">${showDate.toLocaleDateString('en-US', { dateStyle: 'long' })}</span>
+            ${show.time ? `<span class="show-time">· ${show.time}</span>` : ''}
+          </div>
+          <span class="show-venue">${show.venue}</span>
+          ${show.link ? `
+            <span class="show-event">
+              <a href="${show.link}" target="_blank" rel="noopener noreferrer">${show.event || 'Tickets'}</a>
+            </span>` : ''}
+          <span class="show-location">${show.location}</span>
+        </li>
+      `;
+    }).join('');
+  }
+  
+  loadShows();
+  

--- a/assets/js/shows.json
+++ b/assets/js/shows.json
@@ -1,0 +1,178 @@
+[
+    {
+      "date": "2026-01-24",
+      "time": "5:30 - 8:30pm",
+      "venue": "Sam's Chowder House",
+      "event": "",
+      "link": "",
+      "location": "4210 CA-1, Half Moon Bay, CA"
+    },
+    {
+      "date": "2025-11-15",
+      "time": "8pm – 11pm",
+      "venue": "Alhambra Irish House",
+      "event": "",
+      "link": "",
+      "location": "831 Main Street, Redwood City, CA"
+    },
+    {
+      "date": "2025-11-14",
+      "time": "9pm – 10pm",
+      "venue": "The Arbor, Stanford University",
+      "event": "",
+      "link": "",
+      "location": "459 Lagunita Dr, Stanford, CA"
+    },
+    {
+      "date": "2025-11-04",
+      "time": "5:45 - 9:45pm",
+      "venue": "Filoli",
+      "event": "Nightfall",
+      "link": "https://filoli.org/nightfall/",
+      "location": "86 Cañada Rd, Woodside, CA"
+    },
+    {
+      "date": "2025-10-28",
+      "time": "5:45 - 9:45pm",
+      "venue": "Filoli",
+      "event": "Nightfall",
+      "link": "https://filoli.org/nightfall/",
+      "location": "Woodside, CA"
+    },
+    {
+      "date": "2025-10-21",
+      "time": "5:45 - 9:45pm",
+      "venue": "Filoli",
+      "event": "Nightfall",
+      "link": "https://filoli.org/nightfall/",
+      "location": "86 Cañada Rd, Woodside, CA"
+    },
+    {
+      "date": "2025-10-19",
+      "time": "5:45 - 9:45pm",
+      "venue": "Filoli",
+      "event": "Nightfall",
+      "link": "https://filoli.org/nightfall/",
+      "location": "86 Cañada Rd, Woodside, CA"
+    },
+    {
+      "date": "2025-10-15",
+      "time": "5:45 - 9:45pm",
+      "venue": "Filoli",
+      "event": "Nightfall",
+      "link": "https://filoli.org/nightfall/",
+      "location": "86 Cañada Rd, Woodside, CA"
+    },
+    {
+      "date": "2025-09-27",
+      "time": "5:30pm – 9:30pm",
+      "venue": "Roaring Camp Railroads",
+      "event": "Starlight Evening Dinner Party",
+      "link": "https://roaringcamp.com/events",
+      "location": "Felton, CA"
+    },
+    {
+      "date": "2025-09-20",
+      "time": "11:30am – 1:30pm",
+      "venue": "Salesforce Park",
+      "event": "Bluegrass Breeze",
+      "link": "https://www.tjpa.org/media/39988/download?inline",
+      "location": "425 Mission St, San Francisco, CA"
+    },
+    {
+      "date": "2025-09-13",
+      "time": "9pm – 12am",
+      "venue": "Alhambra Irish House",
+      "event": "",
+      "link": "",
+      "location": "831 Main Street, Redwood City, CA"
+    },
+    {
+      "date": "2025-05-23",
+      "time": "",
+      "venue": "The Arbor",
+      "event": "",
+      "link": "",
+      "location": "Palo Alto, CA"
+    },
+    {
+      "date": "2025-05-09",
+      "time": "",
+      "venue": "The Arbor",
+      "event": "",
+      "link": "",
+      "location": "Palo Alto, CA"
+    },
+    {
+      "date": "2025-05-04",
+      "time": "",
+      "venue": "Socks and Sandals",
+      "event": "",
+      "link": "",
+      "location": "Palo Alto, CA"
+    },
+    {
+      "date": "2025-04-19",
+      "time": "",
+      "venue": "Freewheel Brewing Co.",
+      "event": "",
+      "link": "",
+      "location": "Redwood City, CA"
+    },
+    {
+      "date": "2025-03-01",
+      "time": "",
+      "venue": "The Magnolia of Millbrae",
+      "event": "",
+      "link": "",
+      "location": "Millbrae, CA"
+    },
+    {
+      "date": "2025-01-26",
+      "time": "",
+      "venue": "O'Reilly's Pub",
+      "event": "",
+      "link": "",
+      "location": "San Francisco, CA"
+    },
+    {
+      "date": "2025-01-25",
+      "time": "",
+      "venue": "Red Rock Coffee",
+      "event": "",
+      "link": "",
+      "location": "Mountain View, CA"
+    },
+    {
+      "date": "2024-10-04",
+      "time": "",
+      "venue": "The Arbor",
+      "event": "",
+      "link": "",
+      "location": "Palo Alto, CA"
+    },
+    {
+      "date": "2024-08-17",
+      "time": "",
+      "venue": "The Magnolia of Millbrae",
+      "event": "",
+      "link": "",
+      "location": "Millbrae, CA"
+    },
+    {
+      "date": "2024-06-21",
+      "time": "",
+      "venue": "Telluride Bluegrass Festival (Family Tent)",
+      "event": "",
+      "link": "",
+      "location": "Telluride, CO"
+    },
+    {
+      "date": "2024-06-10",
+      "time": "",
+      "venue": "Stanford Farm",
+      "event": "",
+      "link": "",
+      "location": "Palo Alto, CA"
+    }
+  ]  

--- a/shows.html
+++ b/shows.html
@@ -19,7 +19,6 @@
 
   <link rel="icon" href="assets/images/social-preview.jpg" type="image/jpg" />
 
-
   <!-- Main stylesheet -->
   <link rel="stylesheet" href="assets/css/style.css" />
 </head>
@@ -44,227 +43,36 @@
   <!-- Main Content -->
   <main class="container" style="padding: var(--space-xl) 0;">
 
-<!-- Upcoming Shows -->
-<section>
-  <h1>Upcoming Shows</h1>
-  <ul class="show-list">
-<li>
-  <div class="show-datetime">
-    <span class="show-date">October 15, 2025</span>
-    <span class="show-time">· 5:45 - 9:45pm</span>
-  </div>
-  <span class="show-venue">Filoli</span>
-  <span class="show-event">
-    <a href="https://filoli.org/nightfall/" target="_blank" rel="noopener noreferrer">
-      Nightfall
-    </a>
-  </span>
-  <span class="show-location">86 Cañada Rd, Woodside, CA</span>
-</li>
-<li>
-  <div class="show-datetime">
-    <span class="show-date">October 19, 2025</span>
-    <span class="show-time">· 5:45 - 9:45pm</span>
-  </div>
-  <span class="show-venue">Filoli</span>
-  <span class="show-event">
-    <a href="https://filoli.org/nightfall/" target="_blank" rel="noopener noreferrer">
-      Nightfall
-    </a>
-  </span>
-  <span class="show-location">86 Cañada Rd, Woodside, CA</span>
-</li>
-<li>
-  <div class="show-datetime">
-    <span class="show-date">October 21, 2025</span>
-    <span class="show-time">· 5:45 - 9:45pm</span>
-  </div>
-  <span class="show-venue">Filoli</span>
-  <span class="show-event">
-    <a href="https://filoli.org/nightfall/" target="_blank" rel="noopener noreferrer">
-      Nightfall
-    </a>
-  </span>
-  <span class="show-location">86 Cañada Rd, Woodside, CA</span>
-</li>
-<li>
-  <div class="show-datetime">
-    <span class="show-date">October 28, 2025</span>
-    <span class="show-time">· 5:45 - 9:45pm</span>
-  </div>
-  <span class="show-venue">Filoli</span>
-  <span class="show-event">
-    <a href="https://filoli.org/nightfall/" target="_blank" rel="noopener noreferrer">
-      Nightfall
-    </a>
-  </span>
-  <span class="show-location">Woodside, CA</span>
-</li>
-<li>
-  <div class="show-datetime">
-    <span class="show-date">November 4, 2025</span>
-    <span class="show-time">· 5:45 - 9:45pm</span>
-  </div>
-  <span class="show-venue">Filoli</span>
-  <span class="show-event">
-    <a href="https://filoli.org/nightfall/" target="_blank" rel="noopener noreferrer">
-      Nightfall
-    </a>
-  </span>
-  <span class="show-location">86 Cañada Rd, Woodside, CA</span>
-</li>
-<li>
-  <div class="show-datetime">
-    <span class="show-date">Friday November 14, 2025</span>
-    <span class="show-time">· 9pm – 10pm</span>
-  </div>
-    <span class="show-venue">The Arbor, Stanford University</span>
-    <span class="show-event">
-    </span>
-    <span class="show-location">459 Lagunita Dr, Stanford, CA </span>
-</li>
-<li>
-  <div class="show-datetime">
-    <span class="show-date">Saturday November 15, 2025</span>
-    <span class="show-time">· 8pm – 11pm</span>
-  </div>
-    <span class="show-venue">Alhambra Irish House</span>
-    <span class="show-event">
-    </span>
-    <span class="show-location">831 Main Street, Redwood City, CA</span>
-  </li>
-<li>
-  <div class="show-datetime">
-    <span class="show-date">Saturday January 24, 2026</span>
-    <span class="show-time">· 5:30 - 8:30pm</span>
-  </div>
-  <span class="show-venue">Sam's Chowder House</span>
-  <span class="show-location">4210 CA-1, Half Moon Bay, CA</span>
-</li>
-</ul>
-</section>
+    <!-- Upcoming Shows -->
+    <section>
+      <h1>Upcoming Shows</h1>
+      <ul class="show-list" id="upcoming-shows"></ul>
+    </section>
 
-
-
-
-
-    <!-- Single Divider -->
+    <!-- Divider -->
     <hr class="section-divider" />
 
     <!-- Past Shows -->
     <section>
       <h2>Past Shows</h2>
-      <ul class="show-list">
-  <li>
-    <div class="show-datetime">
-      <span class="show-date">September 27, 2025</span>
-      <span class="show-time">· 5:30pm – 9:30pm</span>
-    </div>
-      <span class="show-venue">Roaring Camp Railroads</span>
-      <span class="show-event">
-        <a href="https://roaringcamp.com/events" target="_blank" rel="noopener noreferrer">
-          Starlight Evening Dinner Party
-        </a>
-      </span>
-      <span class="show-location">Felton, CA</span>
-  </li>
-
-        <li>
-    <div class="show-datetime">
-      <span class="show-date">September 20, 2025</span>
-      <span class="show-time">· 11:30am – 1:30pm</span>
-    </div>
-    <span class="show-venue">Salesforce Park</span>
-    <span class="show-location">425 Mission St, San Francisco, CA</span>
-      <span class="show-event">
-    <a href="https://www.tjpa.org/media/39988/download?inline" target="_blank" rel="noopener noreferrer">
-      Bluegrass Breeze
-    </a>
-  </span>
-    </li>
-          <li>
-    <div class="show-datetime">
-      <span class="show-date">September 13, 2025</span>
-      <span class="show-time">· 9pm – 12am</span>
-    </div>
-    <span class="show-venue">Alhambra Irish House</span>
-      <span class="show-event">
-  </span>
-    <span class="show-location">831 Main Street, Redwood City, CA</span>
-    </li>
-      <li>
-        <span class="show-date">May 23, 2025</span>
-        <span class="show-venue">The Arbor</span>
-        <span class="show-location">Palo Alto, CA</span>
-      </li>
-      <li>
-        <span class="show-date">May 9, 2025</span>
-        <span class="show-venue">The Arbor</span>
-        <span class="show-location">Palo Alto, CA</span>
-      </li>
-        <li>
-          <span class="show-date">May 4, 2025</span>
-          <span class="show-venue">Socks and Sandals</span>
-          <span class="show-location">Palo Alto, CA</span>
-        <li>
-        <li>
-          <span class="show-date">April 19, 2025</span>
-          <span class="show-venue">Freewheel Brewing Co.</span>
-          <span class="show-location">Redwood City, CA</span>
-        </li>
-        <li>
-          <span class="show-date">March 1, 2025</span>
-          <span class="show-venue">The Magnolia of Millbrae</span>
-          <span class="show-location">Millbrae, CA</span>
-        </li>
-        <li>
-          <span class="show-date">January 26, 2025</span>
-          <span class="show-venue">O'Reilly's Pub</span>
-          <span class="show-location">San Francisco, CA</span>
-        </li>
-        <li>
-          <span class="show-date">January 25, 2025</span>
-          <span class="show-venue">Red Rock Coffee</span>
-          <span class="show-location">Mountain View, CA</span>
-        </li>
-        <li>
-          <span class="show-date">October 4, 2024</span>
-          <span class="show-venue">The Arbor</span>
-          <span class="show-location">Palo Alto, CA</span>
-        </li>
-        <li>
-          <span class="show-date">August 17, 2024</span>
-          <span class="show-venue">The Magnolia of Millbrae</span>
-          <span class="show-location">Millbrae, CA</span>
-        </li>
-        <li>
-          <span class="show-date">June 21, 2024</span>
-          <span class="show-venue">Telluride Bluegrass Festival (Family Tent)</span>
-          <span class="show-location">Telluride, CO</span>
-        </li>
-        <li>
-          <span class="show-date">June 10, 2024</span>
-          <span class="show-venue">Stanford Farm </span>
-          <span class="show-location">Palo Alto, CA</span>
-        </li>
-      </ul>
+      <ul class="show-list" id="past-shows"></ul>
     </section>
 
   </main>
 
-<!-- Social Links Footer -->
+  <!-- Social Links Footer -->
   <footer class="social-footer">
     <a href="https://instagram.com/theroundercircle" aria-label="Instagram">
       <i class="fab fa-instagram"></i>
     </a>
-        <a href="https://soundcloud.com/the-rounder-circle" aria-label="SoundCloud">
+    <a href="https://soundcloud.com/the-rounder-circle" aria-label="SoundCloud">
       <i class="fab fa-soundcloud"></i>
     </a>
     <a href="https://www.youtube.com/@TheRounderCircle" aria-label="YouTube">
       <i class="fab fa-youtube"></i>
     </a>
 
-        <!-- California poppies graphic -->
+    <!-- California poppies graphic -->
     <img
       src="assets/images/calpoppies.png"
       alt="Illustration of California poppies"
@@ -273,7 +81,7 @@
     <p>&copy; 2025 The Rounder Circle</p>
   </footer>
 
-  <script src="assets/js/main.js"></script>
+  <!-- Load Shows JS -->
+  <script src="assets/js/shows.js"></script>
 </body>
 </html>
- 


### PR DESCRIPTION
Rewrote the logic of the shows tab, to take in a file of all the shows we have ever played or will play, in no particular order (shows.json). shows.html parses this using the logic in shows.js, and automatically sorts by date, organizes into past/upcoming, and visualizes on the website.

So in theory going forward all we need to do to maintain the shows page is to add new gigs to the shows.json file when they come up - moving gigs to past section should now be automated.